### PR TITLE
Update the Audacity appModule

### DIFF
--- a/source/appModules/audacity.py
+++ b/source/appModules/audacity.py
@@ -1,15 +1,14 @@
 #appModules/audacity.py
 #A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2010 NVDA Contributors <http://www.nvda-project.org/>
+#Copyright (C) 2006-2018 NVDA Contributors <https://www.nvaccess.org/>
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
 
 import appModuleHandler
-import winUser
 import controlTypes
 
 class AppModule(appModuleHandler.AppModule):
 
 	def event_NVDAObject_init(self,obj):
 		if obj.windowClassName=="Button" and not obj.role in [controlTypes.ROLE_MENUBAR, controlTypes.ROLE_MENUITEM, controlTypes.ROLE_POPUPMENU]:
-			obj.name=winUser.getWindowText(obj.windowHandle).replace('&','')
+			obj.name=obj.name.replace('&','')


### PR DESCRIPTION
In response to a request from the Audacity developers (issue #8178).
The workaround for buttons is no longer needed.
However, the deletion of ampersand characters will be kept for the sake of backwards compatibility.